### PR TITLE
Add key checking

### DIFF
--- a/src/reason/core.cljs
+++ b/src/reason/core.cljs
@@ -61,16 +61,18 @@
 (defn rule->pred
   "Given a rule, give a predicate for that rule.
    Returns nil if the rule contains keys not in provided keys param."
-  [rule & [rule-keys]]
-  (let [rules (->> rule
-                   (split-rule)
-                   (map parse-subrule)
-                   (create-pred rule-keys))]
-    (fn [record]
-      (->> (reverse rules)
-           (filter (fn [{:keys [pred]}] (pred record)))
-           first
-           :pos?))))
+  ([rule]
+   (rule->pred rule nil))
+  ([rule rule-keys]
+   (let [rules (->> rule
+                    (split-rule)
+                    (map parse-subrule)
+                    (create-pred rule-keys))]
+     (fn [record]
+       (->> (reverse rules)
+            (filter (fn [{:keys [pred]}] (pred record)))
+            first
+            :pos?)))))
 
 (defn ^:private targets-record?
   "Does this subrule affect this record with the this key?"

--- a/src/reason/core.cljs
+++ b/src/reason/core.cljs
@@ -36,13 +36,6 @@
        (first)
        (keyword)))
 
-(defn ^:private clean-subrules
-  "Given keys and subrules, remove the subrules without a matchable value"
-  [kys subrules]
-  (if (seq kys)
-    (filter #(not (nil? (:match-rule %))) subrules)
-    subrules))
-
 (defn ^:private parsed-subrule->pred
   "Given a parsed sub-rule, create a predicate for that rule."
   [{:keys [key-prefix match-rule]}]
@@ -68,12 +61,11 @@
 (defn rule->pred
   "Given a rule, give a predicate for that rule.
    Returns nil if the rule contains keys not in provided keys param."
-  [rule & keys]
+  [rule & [rule-keys]]
   (let [rules (->> rule
                    (split-rule)
                    (map parse-subrule)
-                   (clean-subrules (first keys))
-                   (create-pred (first keys)))]
+                   (create-pred rule-keys))]
     (fn [record]
       (->> (reverse rules)
            (filter (fn [{:keys [pred]}] (pred record)))

--- a/test/reason/core_test.cljs
+++ b/test/reason/core_test.cljs
@@ -159,7 +159,7 @@
   (testing "removes random strings from being included in the predicate"
     (let [record (first some-records)
           rule (str "+id:" (:id record) "; string")
-          pred (rc/rule->pred rule (keys record))]
+          pred (rc/rule->pred rule)]
       (is (pred record))))
 
   (testing "return nil when rule contains keys not provided"

--- a/test/reason/core_test.cljs
+++ b/test/reason/core_test.cljs
@@ -154,7 +154,19 @@
           pred (rc/rule->pred (str control-rule "; +id:" (:id (first records))))]
       (is (not-any? control-pred records))
       (is (pred (first records)))
-      (is (not-any? pred (rest records))))))
+      (is (not-any? pred (rest records)))))
+
+  (testing "removes random strings from being included in the predicate"
+    (let [record (first some-records)
+          rule (str "+id:" (:id record) "; string")
+          pred (rc/rule->pred rule (keys record))]
+      (is (pred record))))
+
+  (testing "return nil when rule contains keys not provided"
+    (let [record (first some-records)
+          rule (str "+id:" (:id record) "; +a:123")
+          pred (rc/rule->pred rule (keys record))]
+      (is (nil? (pred record))))))
 
 (deftest toggle-record-test
   (testing "enable record"


### PR DESCRIPTION
- If a subrule is not parseable, then that piece of the rule is ignored e.g. "id:123; lol" then "lol" is ignored
- If a key used in a rule doesn't exist in the keys provided to `rule->pred` then the predicate will always return `nil`. e.g. "id:123; a:123" with provided keys `[:id]`
