### PR TITLE
Rules with only valid key prefixes create constantly true predicates

### DIFF
--- a/src/reason/core.cljs
+++ b/src/reason/core.cljs
@@ -17,16 +17,14 @@
 
 (defn ^:private parse-subrule
   "Parses a subrule."
-  ([rule]
-   (parse-subrule rule nil))
-  ([rule rule-keys]
-   (let [matches (re-matches #"([-+]?)(.*?):(.*)" (str rule))
-         get-key-prefix (and (nil? matches) (some? rule-keys)
-                             (re-matches #"([-+]?)(.*?)(:?)$" (str rule)))
-         [_ sign key match-rule] (or get-key-prefix matches)]
-     {:pos? (if (= sign "-") false true)
-      :key-prefix key
-      :match-rule match-rule})))
+  [rule rule-keys]
+  (let [matches (re-matches #"([-+]?)(.*?):(.*)" (str rule))
+        get-key-prefix (and (nil? matches) (some? rule-keys)
+                            (re-matches #"([-+]?)(.*?)(:?)$" (str rule)))
+        [_ sign key match-rule] (or get-key-prefix matches)]
+    {:pos? (if (= sign "-") false true)
+     :key-prefix key
+     :match-rule match-rule}))
 
 (defn ^:private prefix?
   "Does super start with sub?"

--- a/src/reason/core.cljs
+++ b/src/reason/core.cljs
@@ -17,11 +17,16 @@
 
 (defn ^:private parse-subrule
   "Parses a subrule."
-  [rule]
-  (let [[_ sign key match-rule] (re-matches #"([-+]?)(.*?):(.*)" (str rule))]
-    {:pos? (if (= sign "-") false true)
-     :key-prefix key
-     :match-rule match-rule}))
+  ([rule]
+   (parse-subrule rule nil))
+  ([rule rule-keys]
+   (let [matches (re-matches #"([-+]?)(.*?):(.*)" (str rule))
+         get-key-prefix (and (nil? matches) (some? rule-keys)
+                             (re-matches #"([-+]?)(.*?)(:?)$" (str rule)))
+         [_ sign key match-rule] (or get-key-prefix matches)]
+     {:pos? (if (= sign "-") false true)
+      :key-prefix key
+      :match-rule match-rule})))
 
 (defn ^:private prefix?
   "Does super start with sub?"
@@ -48,14 +53,20 @@
 
 (defn ^:private create-pred
   "Given keys and the subrules, create a predicate.
-  If not all prefixes are in provided kys vector then predicates return false."
+  If not all prefixes are in provided kys vector then predicates return false.
+  If subrule prefix is in kys vector but doesn't contain a match-rule predicate
+  returns true."
   [kys subrules]
   (let [key-prefixes (map :key-prefix subrules)
         not-all-prefixes-exist?
-        (not-every? #(some? (key-for-prefix % kys)) key-prefixes)
-        pred (if (and (seq kys) not-all-prefixes-exist?)
-               #(constantly false)
-               #(parsed-subrule->pred %))]
+        (and (seq kys)
+             (not-every? #(some? (key-for-prefix % kys)) key-prefixes))
+        prefix-exists-no-rule? #(and (seq kys) (str/blank? (:match-rule %)))
+        pred (fn [subrule]
+               (cond
+                 not-all-prefixes-exist? (constantly false)
+                 (prefix-exists-no-rule? subrule) (constantly true)
+                 :else (parsed-subrule->pred subrule)))]
     (map (fn [subrule] (assoc subrule :pred (pred subrule))) subrules)))
 
 (defn rule->pred
@@ -66,7 +77,7 @@
   ([rule rule-keys]
    (let [rules (->> rule
                     (split-rule)
-                    (map parse-subrule)
+                    (map #(parse-subrule % rule-keys))
                     (create-pred rule-keys))]
      (fn [record]
        (->> (reverse rules)

--- a/test/reason/core_test.cljs
+++ b/test/reason/core_test.cljs
@@ -17,7 +17,7 @@
       "single semicolon at end of string is ignored"))
 
 (deftest parse-subrule-test
-  (are [subrule parsed] (= (rc/parse-subrule subrule) parsed)
+  (are [subrule parsed] (= (rc/parse-subrule subrule nil) parsed)
     "+id:abc"
     {:pos? true
      :key-prefix "id"
@@ -181,7 +181,7 @@
       (is (pred (first records)))
       (is (not-any? pred (rest records)))))
 
-  (testing "fails on non prefix keys"
+  (testing "fails on non-prefix keys"
     (let [record (first some-records)]
       (are [rule] (nil? ((rc/rule->pred rule (keys record)) record))
         "str"
@@ -195,6 +195,7 @@
         "id"
         "id:"
         (str "+id:" (:id record) "; nam")
+        (str "+id:" (:id record) "; nam; status")
         (str "+id:" (:id record) "; nam:" (:name record))))))
 
 (deftest toggle-record-test

--- a/test/reason/core_test.cljs
+++ b/test/reason/core_test.cljs
@@ -17,7 +17,8 @@
       "single semicolon at end of string is ignored"))
 
 (deftest parse-subrule-test
-  (are [subrule parsed] (= (rc/parse-subrule subrule nil) parsed)
+  (are [subrule parsed] (and (= (rc/parse-subrule subrule nil) parsed)
+                             (= (rc/parse-subrule subrule [:id]) parsed))
     "+id:abc"
     {:pos? true
      :key-prefix "id"
@@ -33,27 +34,13 @@
      :key-prefix "id"
      :match-rule "abc"})
 
-  (are [subrule kys parsed] (= (rc/parse-subrule subrule kys) parsed)
-    "+id:abc"
-    [:id]
-    {:pos? true
-     :key-prefix "id"
-     :match-rule "abc"}
-
-    "id:abc"
-    [:id]
-    {:pos? true
-     :key-prefix "id"
-     :match-rule "abc"}
-
+  (are [subrule parsed] (= (rc/parse-subrule subrule [:id]) parsed)
     "id"
-    [:id]
     {:pos? true
      :key-prefix "id"
      :match-rule ""}
 
     "id:"
-    [:id]
     {:pos? true
      :key-prefix "id"
      :match-rule ""}))


### PR DESCRIPTION
If a kys param is provided to `rule->pred` then true should be returned in cases where the rule may only contain a prefix.
e.g. `(rule->pred "id" [:id])` returns true for any map containing `:id`
